### PR TITLE
Optionally use setuptools in setup.py.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,9 @@
 #! /usr/bin/env python
 
-from distutils.core import setup
+try:
+    from setuptools import setup
+except ImportError:
+    from distutils.core import setup
 
 setup(
     name='halfedge_mesh',


### PR DESCRIPTION
- setuptools allows extra functions like 'python setup.py develop'
- Fall back on distutils, which is part of python, if setuptools is
  not available
